### PR TITLE
Outer CV

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,49 @@ All other meta-data (such as runtime cutoff) has to be specified by command line
 
 ### Cross-Validation Mode
 
-The default mode of AutoFolio is running a 10-fold cross validation to estimate the performance of AutFolio.
+The default mode of AutoFolio is running a 10-fold cross-validation to estimate the performance of AutoFolio.
+
+### "Outer" Cross-Validation Mode
+
+"Outer" cross-validation again uses a 10-fold cross-validation scheme to
+evaluate AutoFolio; in this case, though, the subset for testing is not at all
+seen by AutoFolio during training. Internally, the nine training folds are
+further use in an "inner" cross-validation to avoid overfitting.
+
+The `--outer-cv` flag indicates to use this mode. For example:
+
+```
+autofolio -s aslib_data/BNSL-2016/ --outer-cv
+
+```
+#### Saving the outer cross-validation choices
+
+The learned model and solver choices for each instance can be saved using the
+`--out-template` option. If given, the fit model and solver choices will be
+saved to this location. The string is considered a template. "${fold}" will be 
+replaced with the outer cv fold, and "${type}" will be replaced with the 
+appropriate file extension, "pkl" for the models and "csv" for the solver 
+choices. See string.Template for more details about valid tempaltes.
+
+**N.B.** In many shells (such as bash), it is necessary to put the template in 
+single quotes to avoid shell replacement in the template. (Double quotes will
+not typically work.)
+
+```
+autofolio -s aslib_data/BNSL-2016/ --outer-cv --out-template 'bnsl.fold-${fold}.${type}'
+
+```
+#### Parallelizing the outer cross-validation
+
+Optionally, only a single "outer" cv fold can be run. Presumably, this is used
+to parallelize the outer cv calls across a cluster. The `--outer-cv-fold` option
+specifies which fold is used. Typically, this option would be combined with
+`--out-template`, and the results would be combined in post-processing.
+
+```
+autofolio -s aslib_data/BNSL-2016/ --outer-cv --outer-cv-fold 1 --out-template 'bnsl.fold-${fold}.${type}'
+```
+
 
 ### Prediction Mode
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,42 @@ One file with the performance data of each algorithm on each instance (each row 
 And another file with the instance features for each instance (each row an instance and each column an feature).
 All other meta-data (such as runtime cutoff) has to be specified by command line options (see `python3 scripts/autofolio --help`).
 
+### Configuration file
+
+A YAML configuration file can be given to control some of the internal AutoFolio
+behavior. It is given with the `--config` option. 
+
+The recognized options and their types are as follows.
+
+* `wallclock_limit`. The amount of time (in seconds) for optimizing 
+  hyperparameters. Type: integer. Default: 2 days.
+
+#### Feature groups
+  
+* `allowed_feature_groups`. A list of the feature groups to consider for 
+  prediction. This must match those specified in the ASlib scenario. Type: list
+  of strings. Default: all feature sets are allowed.
+
+#### Preprocessing
+
+* `pca`. Whether to include PCA as a choice for preprocessing. Type: Boolean. Default: True.
+
+* `impute`. Whether missing value imputation is a choice for preprocessing. Type: Boolean. Default: True.
+
+* `scale`. Whether z-score scaling is a choice for preprocessing. Type: Boolean. Default: True.
+
+#### Presolving
+
+* `presolve`. Whether to use a presolver. Type: Boolean. Default: True.
+
+#### Algorithm selection model classes
+
+* `random_forest_classifier`. Whether the random forest classifier is a model class choice. Type: Boolean. Default: True.
+
+* `xgboost_classifier`. Whether the XGBoost classifier is a model class choice. Type: Boolean. Default: True.
+
+* `random_forest_regressor`. Whether the random forest regressor is a model class choice. Type: Boolean. Default: True.
+
 ### Cross-Validation Mode
 
 The default mode of AutoFolio is running a 10-fold cross-validation to estimate the performance of AutoFolio.
@@ -99,6 +135,8 @@ Optionally, only a single "outer" cv fold can be run. Presumably, this is used
 to parallelize the outer cv calls across a cluster. The `--outer-cv-fold` option
 specifies which fold is used. Typically, this option would be combined with
 `--out-template`, and the results would be combined in post-processing.
+
+**N.B.** This number should range from 1 to 10 (not 0 to 9).
 
 ```
 autofolio -s aslib_data/BNSL-2016/ --outer-cv --outer-cv-fold 1 --out-template 'bnsl.fold-${fold}.${type}'

--- a/autofolio/autofolio.py
+++ b/autofolio/autofolio.py
@@ -753,3 +753,12 @@ class AutoFolio(object):
             return dict((inst, pre_solving_schedule.get(inst, []) + schedule) for inst, schedule in pred_schedules.items())
         else:
             return pred_schedules
+
+
+def main():
+    af = AutoFolio()
+    af.run_cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/autofolio/io/cmd.py
+++ b/autofolio/io/cmd.py
@@ -49,6 +49,35 @@ class CMDParser(object):
         opt.add_argument("--feature_vec", default=None, nargs="*",
                          help="feature vector to predict algorithm to use -- has to be used in combination with --load")
 
+        opt.add_argument("--config", type=str, default=None,
+                              help="(yaml) config file with run-specific "
+                              "configuration options for autofolio")
+
+        outer_cv = self._arg_parser.add_argument_group("Outer Cross-fold Validation Options")
+
+        outer_cv.add_argument("--outer-cv", action="store_true", default=False,
+                              help="Use an \"outer\" cross-fold validation scheme "
+                              "for tuning to ensure that SMAC does not peek at "
+                              "the test set during hyperparameter optimization.")
+
+        outer_cv.add_argument("--outer-cv-fold", type=int, default=None,
+                              help="If this argument is given in --outer-cv "
+                              "mode, then only the specified outer-cv fold "
+                              "will be processed. Presumably, the learned "
+                              "model will be saved using --save and the "
+                              "results for all folds will be combined later.")
+
+        outer_cv.add_argument("--out-template", type=str, default=None,
+                              help="If given, then the fit model and solver "
+                              "choices will be saved to this location. The "
+                              "string is considered a template. \"$fold\" "
+                              "will be replaced with the fold, and "
+                              "\"$type\" will be replaced with the "
+                              "appropriate file extension, \"pkl\" for the "
+                              "models and \"csv\" for the solver choices. See "
+                              "string.Template for more details about valid "
+                              "tempaltes.")
+
     def parse(self):
         '''
             uses the self._arg_parser object to parse the cmd line arguments

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 import os
 import setuptools
 
-
 requirements = ['ConfigSpace', 'numpy', 'scipy', 'scikit-learn', 'pandas', 'smac', 'xgboost']
+
+console_scripts = [
+    'autofolio=autofolio.autofolio:main'
+]
 
 setuptools.setup(
     name="autofolio",
@@ -25,5 +28,8 @@ setuptools.setup(
     install_requires=requirements,
     tests_require=['mock',
                    'nose'],
-    test_suite='nose.collector'
+    test_suite='nose.collector',
+    entry_points = {
+        'console_scripts': console_scripts
+    }
 )


### PR DESCRIPTION
This PR includes the following changes.

* Add an "outer" cross-validation loop to AutoFolio. In particular, this ensures the test set is not seen by the learner until testing. The readme documents all of the the related options.

* Add an optional YAML configuration file to control some of the behavior of the learner, including which feature groups, preprocessors and model classes are available. The readme documents all of the the related options.

* Create an `autofolio` console script when installing via setup. **N.B.** This has problems locating `runsolver` (and presumably `clingo`) because of the default paths in `aspeed_schedule.Aspeed.__init__`. Currently, there does not appear to be a way to pass other paths to it; one option could be to check `$PATH`, then use the current defaults.

