### PR TITLE
returned predicted algorithm

### DIFF
--- a/autofolio/autofolio.py
+++ b/autofolio/autofolio.py
@@ -90,7 +90,7 @@ class AutoFolio(object):
         if args_.load:
             pred = self.read_model_and_predict(
                 model_fn=args_.load, feature_vec=list(map(float, args_.feature_vec)))
-            print("Selected Schedule [(algorithm, budget)]: %s" % (pred))
+            print("Selected Schedule (algorithm, budget): %s" % (pred))
 
         else:
 
@@ -295,6 +295,11 @@ class AutoFolio(object):
                 file name of saved model
             feature_vec: list
                 instance feature vector as a list of floats 
+
+            Returns
+            -------
+            tuple
+                Selected schedule (algorithm, budget)
         '''
         with open(model_fn, "br") as fp:
             scenario, feature_pre_pipeline, pre_solver, selector, config = pickle.load(
@@ -314,7 +319,7 @@ class AutoFolio(object):
         pred = self.predict(scenario=scenario, config=config,
                             feature_pre_pipeline=feature_pre_pipeline, pre_solver=pre_solver, selector=selector)
 
-        return pred["pseudo_instance"]
+        return pred["pseudo_instance"][0]
 
     def get_cs(self, scenario: ASlibScenario, autofolio_config:dict=None):
         '''

--- a/autofolio/autofolio.py
+++ b/autofolio/autofolio.py
@@ -88,8 +88,9 @@ class AutoFolio(object):
         self._root_logger.setLevel(args_.verbose)
 
         if args_.load:
-            self.read_model_and_predict(
+            pred = self.read_model_and_predict(
                 model_fn=args_.load, feature_vec=list(map(float, args_.feature_vec)))
+            print("Selected Schedule [(algorithm, budget)]: %s" % (pred))
 
         else:
 
@@ -313,8 +314,7 @@ class AutoFolio(object):
         pred = self.predict(scenario=scenario, config=config,
                             feature_pre_pipeline=feature_pre_pipeline, pre_solver=pre_solver, selector=selector)
 
-        print("Selected Schedule [(algorithm, budget)]: %s" % (
-            pred["pseudo_instance"]))
+        return pred["pseudo_instance"]
 
     def get_cs(self, scenario: ASlibScenario, autofolio_config:dict=None):
         '''

--- a/autofolio/autofolio.py
+++ b/autofolio/autofolio.py
@@ -90,7 +90,7 @@ class AutoFolio(object):
         if args_.load:
             pred = self.read_model_and_predict(
                 model_fn=args_.load, feature_vec=list(map(float, args_.feature_vec)))
-            print("Selected Schedule (algorithm, budget): %s" % (pred))
+            print("Selected Schedule [(algorithm, budget)]: %s" % (pred))
 
         else:
 
@@ -298,8 +298,8 @@ class AutoFolio(object):
 
             Returns
             -------
-            tuple
-                Selected schedule (algorithm, budget)
+            list of tuple
+                Selected schedule [(algorithm, budget)]
         '''
         with open(model_fn, "br") as fp:
             scenario, feature_pre_pipeline, pre_solver, selector, config = pickle.load(
@@ -319,7 +319,7 @@ class AutoFolio(object):
         pred = self.predict(scenario=scenario, config=config,
                             feature_pre_pipeline=feature_pre_pipeline, pre_solver=pre_solver, selector=selector)
 
-        return pred["pseudo_instance"][0]
+        return pred["pseudo_instance"]
 
     def get_cs(self, scenario: ASlibScenario, autofolio_config:dict=None):
         '''


### PR DESCRIPTION
I want to use the AutoFolio prediction mode within a python script, so without making use of the cli. I can import the AutoFolio class and run "read_model_and_predict", but this forces me to redirect the stdout and parse it to obtain the predicted algorithm.

This modification returns the predicted algorithm and moves the print statement to the "run_cli" function.