### PR TITLE
Delete note on required SMAC development branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ You should have received a copy of the 2-clause BSD license along with this prog
 
 ### Requirements
 
-NOTE: AutoFolio requires the future SMAC 0.9; currently only available in the [development branch of SMAC](https://github.com/automl/SMAC3/tree/development)
-
 AutoFolio runs with '''Python 3.5'''.
 
 To install (nearly) all requirements, please run:


### PR DESCRIPTION
The current SMAC master branch is already beyond v0.9. The SMAC development branch does not contain "smac.facade.smac_facade" anymore, causing AutoFolio to crash.